### PR TITLE
Change generated fake so MakeFile command to perl

### DIFF
--- a/lib/Native/Resources/Build.pm
+++ b/lib/Native/Resources/Build.pm
@@ -30,7 +30,7 @@ module Native::Resources::Build {
         %vars<FAKESO> = @fake-shared-object-extensions.map("resources/lib/lib$libname" ~ *).eager;
 
         my $fake-so-rules = %vars<FAKESO>.map(-> $filename {
-            qq{$filename:\n\tperl6 -e "print ''" > $filename}
+            qq{$filename:\n\tperl -e "print ''" > $filename}
         }).join("\n");
 
         mkdir($destfolder);


### PR DESCRIPTION
Installing modules to Windows sometimes fails as the default tool chain uses Strawberry perl's mingw tool set which does not examine the Window's PATH environment variable and as such is missing the perl6 bin directory from it's own path.
Changing the command to use perl fixes this.
